### PR TITLE
[proposal] Change engines to >=6

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.7",
   "description": "CSSOM-valid and jsdom/Jest-compatible matchMedia polyfill for server-side unit tests",
   "engines": {
-    "node": ">=7.*"
+    "node": ">=6.*"
   },
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
First off, great work on this library 👍 💯 

We were looking to integrate this into one of our projects, but we are on Node 6.x and the package.json is scoped to an engine of 7 or greater. Node 6 is the current version that is in long-term support, so it'd be great if that was supported here as well. https://github.com/nodejs/LTS