### PR TITLE
(docs): use window-resizeto polyfill to simplify code

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ npm install --save-dev mq-polyfill
 ```javascript
 import { jsdom } from 'jsdom';
 import matchMediaPolyfill from 'mq-polyfill';
+import { resizeTo } from 'window-resizeto';
 
 const window = jsdom().defaultView;
 
@@ -32,14 +33,9 @@ window
  * For dispatching resize event
  * we must implement window.resizeTo in jsdom
  */
-window.resizeTo = function resizeTo(width, height) {
-  Object.assign(this, {
-    innerWidth: width,
-    innerHeight: height,
-    outerWidth: width,
-    outerHeight: height,
-  }).dispatchEvent(new this.Event('resize'));
-};
+window.resizeTo = function (width, height) {
+  resizeTo(this, width, height);
+}
 
 window.resizeTo(800, 600);
 // console.log() output:


### PR DESCRIPTION
- instead of polyfilling it oneself or introducing potentially
  confusing code

- and the /polyfill import can also be recommended for Jest
  environments for even greater simplicity

See [`window-resizeto`](https://github.com/agilgur5/window-resizeto)'s docs for more info and different use-cases (including `window-resizeto/polyfill`).
It was made to solve this issue and re-use test code between projects so one doesn't have to copy/paste code to manually polyfill this when needed.

Might want to recommend installing it too in the README